### PR TITLE
Section 4 unit test

### DIFF
--- a/src/main/java/com/udemy/dropbookmarks/resources/Hello.java
+++ b/src/main/java/com/udemy/dropbookmarks/resources/Hello.java
@@ -14,7 +14,7 @@ public enum Hello {
 	/**
 	 * 
 	 */
-	SECURED_HELLO_WORLD("Hello secured world!", "/hello/secured");
+	HELLO_SECURED_WORLD("Hello secured world!", "/hello/secured");
 	
 	/**
 	 * 

--- a/src/main/java/com/udemy/dropbookmarks/resources/HelloResource.java
+++ b/src/main/java/com/udemy/dropbookmarks/resources/HelloResource.java
@@ -5,6 +5,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import com.udemy.dropbookmarks.core.User;
+
+import io.dropwizard.auth.Auth;
+
 /**
  * 
  * @author icampbell2
@@ -29,7 +33,7 @@ public final class HelloResource {
 	@GET
 	@Produces(MediaType.TEXT_PLAIN)
 	@Path("/secured") // sub-resource path as /hello/secured
-	public String getSecuredGreeting() {
-		return Hello.SECURED_HELLO_WORLD.getGreeting();
+	public String getSecuredGreeting(@Auth User user) {
+		return Hello.HELLO_SECURED_WORLD.getGreeting();
 	}
 }

--- a/src/test/java/com/udemy/dropbookmarks/resources/HelloResourceTest.java
+++ b/src/test/java/com/udemy/dropbookmarks/resources/HelloResourceTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import javax.ws.rs.core.MediaType;
 
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -26,6 +28,11 @@ public final class HelloResourceTest {
 	/**
 	 * 
 	 */
+	private static final HttpAuthenticationFeature FEATURE = HttpAuthenticationFeature.basic("u", "p");
+	
+	/**
+	 * 
+	 */
 	private static final Authenticator<BasicCredentials, User> AUTHENTICATOR = new Authenticator<BasicCredentials, User>() {
 
 		@Override
@@ -34,11 +41,22 @@ public final class HelloResourceTest {
 		}		
 	};
 
+	/**
+	 * 
+	 */
 	@ClassRule
 	public static final ResourceTestRule RULE = ResourceTestRule.builder()
 			.addProvider(AuthFactory.binder(new BasicAuthFactory<>(AUTHENTICATOR, "realm", User.class)))
 			.addResource(new HelloResource())
 			.build();
+	
+	/**
+	 * 
+	 */
+	@BeforeClass
+	public static final void setUpClass() {
+		RULE.getJerseyTest().client().register(FEATURE);
+	}
 	
 	/**
 	 * 

--- a/src/test/java/com/udemy/dropbookmarks/resources/HelloResourceTest.java
+++ b/src/test/java/com/udemy/dropbookmarks/resources/HelloResourceTest.java
@@ -33,4 +33,18 @@ public final class HelloResourceTest {
 		
 		assertEquals(result, helloWorld.getGreeting());
 	}
+	
+	/**
+	 * 
+	 */
+	@Test
+	public void testGetSecuredGreeting() {
+		Hello helloSecuredWorld = Hello.HELLO_SECURED_WORLD;
+		String result = RULE.getJerseyTest()
+				.target(helloSecuredWorld.getPath())
+				.request(MediaType.TEXT_PLAIN)
+				.get(String.class);
+		
+		assertEquals(result, helloSecuredWorld.getGreeting());
+	}
 }

--- a/src/test/java/com/udemy/dropbookmarks/resources/HelloResourceTest.java
+++ b/src/test/java/com/udemy/dropbookmarks/resources/HelloResourceTest.java
@@ -7,6 +7,14 @@ import javax.ws.rs.core.MediaType;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import com.google.common.base.Optional;
+import com.udemy.dropbookmarks.core.User;
+
+import io.dropwizard.auth.AuthFactory;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.basic.BasicAuthFactory;
+import io.dropwizard.auth.basic.BasicCredentials;
 import io.dropwizard.testing.junit.ResourceTestRule;
 
 /**
@@ -14,9 +22,21 @@ import io.dropwizard.testing.junit.ResourceTestRule;
  * @author icampbell2
  */
 public final class HelloResourceTest {
+	
+	/**
+	 * 
+	 */
+	private static final Authenticator<BasicCredentials, User> AUTHENTICATOR = new Authenticator<BasicCredentials, User>() {
+
+		@Override
+		public Optional<User> authenticate(BasicCredentials credentials) throws AuthenticationException {
+			return Optional.of(new User());
+		}		
+	};
 
 	@ClassRule
 	public static final ResourceTestRule RULE = ResourceTestRule.builder()
+			.addProvider(AuthFactory.binder(new BasicAuthFactory<>(AUTHENTICATOR, "realm", User.class)))
 			.addResource(new HelloResource())
 			.build();
 	


### PR DESCRIPTION
Three attempts at creating a unit test for a password-protected resource with Jersey are shown:
- [78afe9c](https://github.com/icampbell2/DropBookmarks/commit/78afe9c6c68e0c6e4523bce9c1ce5ef4a6de3d00):  User is not injected to +HelloResource#getSecuredGreeting(User):String, currently null
- [ec8a1e3](https://github.com/icampbell2/DropBookmarks/commit/ec8a1e3cf5d2856678ac708cd64a39e89fac94aa):  fails on 401 Unauthorized, credentials must be supplied every time a method is called
- [532130c](https://github.com/icampbell2/DropBookmarks/commit/532130c0f14d1c81b26b9841a6afd055a8d86d8c):  added authentication, but Jersey isn't calling the authenticate method; still fails on 401 Unauthorized

In Section 5, [Grizzly](https://jersey.java.net/project-info/2.5.1/jersey/project/project/jersey-test-framework-provider-grizzly2/dependencies.html) will be used for unit test injection.
